### PR TITLE
Correct definition of apis constant.

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -4,7 +4,7 @@ exports.sourceNodes = (
   configOptions
 ) => {
   const { createNode } = actions
-  const { apis } = configOptions
+  const apis = configOptions.urls
 
   // Gatsby adds a configOption that's not needed for this plugin, delete it
   delete configOptions.plugins


### PR DESCRIPTION
Closes #10 

I'll say it before and I'll say it again: I'm not a `*` developer, but this change fixed the plugin for my setup, as defined in the issue.

Essentially it changes `const { apis } = configOptions` to `const apis = configOptions.urls`.