### PR TITLE
Revert "Add dummy node"

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -10,107 +10,14 @@ exports.sourceNodes = (
   delete configOptions.plugins
 
   const sources = []
-  const dummyData = {
-    id: 'dummy',
-    appointment: '',
-    bio: '',
-    building: '',
-    consult_service: '',
-    experience: '',
-    grant_contract: '',
-    honor_award: '',
-    innovate_enterpreneur: '',
-    patent_invention: '',
-    pf_email: '',
-    pf_work_fax: '',
-    pf_first_name: '',
-    pf_last_name: '',
-    pf_work_phone: '',
-    pf_title: '',
-    pf_username: '',
-    website: '',
-    research: '',
-    room: '',
-    photo_base64: '',
-    notable_courses: '',
-    school: '',
-    service_university: [
-      {
-        org: '',
-        member_type: '',
-      },
-    ],
-    service_professional: [
-      {
-        title: '',
-        org: '',
-      },
-    ],
-    education: [
-      {
-        dty_comp: '',
-        deg: '',
-        degother: '',
-        school: '',
-        state: '',
-        country: '',
-        major: '',
-      },
-    ],
-    member: [
-      {
-        org: '',
-        status: '',
-      },
-    ],
-    intellcont: [
-      {
-        contype: '',
-        contypeother: '',
-        journal_name: '',
-        pagenum: '',
-        status: '',
-        title: '',
-        volume: '',
-        publisher: '',
-        pubctyst: '',
-        issue: '',
-        dty_pub: '',
-        dty_acc: '',
-        dty_sub: '',
-        web_address: '',
-        intellcont_auth: {
-          faculty_name: '',
-          fname: '',
-          lname: '',
-        },
-      },
-    ],
-  }
 
-  const dummyNodeContent = JSON.stringify(dummyData)
-
-  const dummyNodeMeta = {
-    id: createNodeId(`PeopleFaculty-dummy`),
-    endpointId: 'dummy',
-    parent: null,
-    children: [],
-    internal: {
-      type: `MultiApiSourcePeopleFaculty`,
-      content: dummyNodeContent,
-      contentDigest: createContentDigest(dummyData),
-    },
-  }
-
-  const dummyNode = Object.assign({}, dummyData, dummyNodeMeta)
-  createNode(dummyNode)
   // Helper function that processes a result to match Gatsby's node structure
   const processResult = ({ result, endpoint, prefix }) => {
-    const nodeId = createNodeId(`${endpoint}-${result.pf_username}`)
+    const nodeId = createNodeId(`${endpoint}-${result.id}`)
     const nodeContent = JSON.stringify(result)
-    const meta = {
+    const nodeData = Object.assign({}, result, {
       id: nodeId,
-      endpointId: result.pf_username,
+      endpointId: result.id,
       parent: null,
       children: [],
       internal: {
@@ -118,11 +25,7 @@ exports.sourceNodes = (
         content: nodeContent,
         contentDigest: createContentDigest(result),
       },
-    }
-    const nodeData = Object.assign({}, result, meta)
-    console.log('meta.type: ' + meta.internal.type)
-    console.log('result.id: ' + result.id)
-    console.log('result.pf_username: ' + result.pf_username)
+    })
 
     return nodeData
   }


### PR DESCRIPTION
Reverts danspratling/gatsby-source-multi-api#17

Turns out while this is great and doesn't cause any errors, some of the node names are very unique and not clear for general audiences.

Reverting to maintain clarity.